### PR TITLE
Sync transactions to disk before changing model state.

### DIFF
--- a/airomem-core/src/main/java/pl/setblack/airomem/core/builders/PrevaylerBuilder.java
+++ b/airomem-core/src/main/java/pl/setblack/airomem/core/builders/PrevaylerBuilder.java
@@ -159,7 +159,7 @@ public class PrevaylerBuilder<T extends Serializable> {
             PrevaylerFactory<RoyalFoodTester> factory = new PrevaylerFactory<>();
             factory.configurePrevalentSystem(createRoot());
 
-            factory.configureJournalDiskSync(false);
+            factory.configureJournalDiskSync(true);
             factory.configurePrevalenceDirectory(PersistenceDiskHelper.calcFolderName(this.getFolder()));
 
             factory.configureJournalSerializer(createSerializer(isUseFastJournalSerialization()));


### PR DESCRIPTION
Is this not required to guarantee ACID properties ?

I spent quite some time trying to understand why the .journal file was not growing in size
with each request. It's confusing for a new user.

Data integrity in case of power outage seems more important to a persistence engine,
than performance.